### PR TITLE
Clarify the D2 maintainer invitation

### DIFF
--- a/blog/non-profit.md
+++ b/blog/non-profit.md
@@ -22,7 +22,8 @@ development and am excited for the roadmap ahead.
 If you have interest in becoming a maintainer, please email me at
 [alex@d2lang.com](mailto:alex@d2lang.com). High-quality maintenance and contributions
 may be invited to enter into a paid contributor contract, funded by donations to
-the non-profit.
+the non-profit. This would be ideal for a driven early-careerist with open-source
+experience.
 
 <!-- truncate -->
 


### PR DESCRIPTION
## Human

---

## AI

Add the author's requested closing sentence to the maintainer invitation in “D2 is non-profit”: “This would be ideal for a driven early-careerist with open-source experience.”

Validation: `git diff --check` passed; site build and repository checks run in CI.
