### PR TITLE
Correct TALA announcement URL and add acknowledgments

### DIFF
--- a/blog/tala-layouts.mdx
+++ b/blog/tala-layouts.mdx
@@ -2,7 +2,7 @@
 date: 2026-09-07
 title: TALA is open-source
 description: Seven real-world layout comparisons and eleven original diagrams, including two with selective TALA positioning.
-slug: tala-layouts
+slug: tala-is-open-source
 hide_table_of_contents: false
 hide_reading_time: true
 ---
@@ -42,6 +42,8 @@ Please also note that TALA is not without tradeoffs.
 - It can take longer to run for larger diagrams -- scaling nonlinearly. For a benchmark of TALA's runtime performance compared to others, see [https://github.com/d2lang/d2-benchmarks](https://github.com/d2lang/d2-benchmarks).
 
 TALA comes bundled into D2 v0.9.0, so just install and specify with `--layout=tala` to try it out! Or head on over to [https://play.d2lang.com](https://play.d2lang.com/?layout=tala&script=7Jjfb-JGEMff_VeMLs8YWJOGbqVK6fWqVsq1dyRVXipFY--AVzG7vt11I3rif6_8C2xwCknjpJV4ifES5vPd-eUdn8G1zkxEHGLnUsuHw4V0cRb6kV4OFzpBtRh8ySijYfk3THQ4ZHjxbThFjIJvCCO8OJ_O55P5-WTM5lE4mZ6HI3YhxPl0KJe4IDucJ_phMAp8wbwzuJIRKUscPv5y8x1YIph9uLy6u_1tdvWjvxS-dwaXAlOHTmrF4SaWRgxSNG4FMtLKgqE0wYgEPEgXQ5jJxA2kggRDSkiAjTEl63uekIai0oiRi9h5XmbJjMYcfi-u8NWD8r85pGSsVvm9WyXEi68AllniZJrfO5NRsRTqRDRu51q5gZV_EQc29QDW3rrCsArD-sUEFSboFzOpMJPeMJFWDqUic5caLbKIzF0eqmsyf8qIqmjthXSHfRDkATi096Nx_YvWzzvF71lt2Q1YsbZuWWd9WS9qkMPn_AJXMjRoVt2of7LKpvWaTBIOsVa0EvRQoYpLHQMOn6pPG8s7oA5U1xa2uE-Y4gpvY5m2vhik6BwZxWFhUKqGdSPIDAwKmVkO0xaDw1IrXS2tOyIxhsH3pdf87ZY-qGIFbtDed3sPlVyiI3F0oNi0A87eAv5IKbFtKbFTKZ1K6VRKR5WSQIchWuIwk2rxh_ohm8_JNB-C0SqRSpA5vn6qMLYjlUhF1tsLRiFCu5jMnXXaEId37-DrLkunGEm34jCqnWZISMthll9q1-zpfVKmB6yx1kqWLd2_aIfOYBhKt_zCYYZhqN3Hz20tRfheSsiGqtBZDr9e3lz3SHt0263-m59Xs2V1lLnV5n5z7jy131dqv3UIOLyvPv3v2m_Z9-qN5J2wjvzPqETSa_d9hM2OYD_vyLItGbYpmdOJZWM96NX6pNdyH41PBX98wY_YyVtP8Nb4LRvkaPy8FvlCdLZPD96UPumdvva8szx5VflIqN_t5Qo63yT5dUa8N4SuoaulqkPT8S_8DrBZj-zgMTbrf9-TA-ye9t3t6faImCvbTnDX-QDVvwjWIaIxwfnboei_IqicFbsGyx1kY-QJ_g2xnNCeCawD2k67xqTlt8-sHH4iF8Uv6-dDIpi_-1zoRUZXXh2SxF5RUp5ZT9FzRErsQruTZDfb3kLE3wMA&), which runs 100% client-side. I especially look forward to the improvements that being open-source brings, and can't wait to see what improvements and ideas are submitted by the community.
+
+Special thanks to Gavin Nishizawa for substantial broad contributions across TALA, and Júlio César Batista for his work on hierarchy algorithms and more.
 
 ## Batch 1: Comparisons
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -221,6 +221,10 @@ const config: Config = {
         fromExtensions: ["html", "htm"],
         redirects: [
           {
+            to: "/blog/tala-is-open-source/",
+            from: ["/blog/tala-layouts/"],
+          },
+          {
             to: "/tour/intro/",
             from: ["/tour"],
           },


### PR DESCRIPTION
## Human

---

## AI

Move the TALA announcement to `/blog/tala-is-open-source/` and publish the author’s new acknowledgments paragraph verbatim. Redirect `/blog/tala-layouts/` to the new URL, preserving query parameters and section anchors through the existing Docusaurus redirect plugin.

Validation: English and Korean production builds, generated canonical URLs and redirects, and exact preservation of the author’s edited post apart from the slug.
