### PR TITLE
fix(blog): details block unreadable in dark mode

### DIFF
--- a/src/styles/custom.scss
+++ b/src/styles/custom.scss
@@ -31,7 +31,8 @@ strong {
   --button-hover: var(--steel-800);
   --icon-filter: var(--white-filter);
 
-  .theme-admonition {
+  .theme-admonition,
+  details.alert {
     background: var(--steel-800);
   }
 }


### PR DESCRIPTION
This PR fixes the collapsible details block in blog posts showing white text on a light blue background in dark mode.

before -

<img width="1057" height="700" alt="image" src="https://github.com/user-attachments/assets/a7574a27-dfd0-4040-acc4-804b0069a8d7" />


after -

<img width="1057" height="700" alt="image" src="https://github.com/user-attachments/assets/6d390386-d30f-41f3-a77e-994982f22216" />
