### PR TITLE
Fix dark mode for MDX disclosures

### DIFF
--- a/src/styles/custom.scss
+++ b/src/styles/custom.scss
@@ -31,7 +31,8 @@ strong {
   --button-hover: var(--steel-800);
   --icon-filter: var(--white-filter);
 
-  .theme-admonition {
+  .theme-admonition,
+  details.alert--info {
     background: var(--steel-800);
   }
 }


### PR DESCRIPTION
## Human

---

## AI

In dark mode, the TALA announcement's “Sources and rendering details” disclosure uses nearly white text on a pale background. Apply the existing dark admonition background to Docusaurus `details.alert--info` elements so the collapsed label and expanded contents are readable. Light mode and diagram colors are unchanged.

Validation: production build passed for English and Korean; repository-pinned Prettier 2.8.1 at print width 90 and `git diff --check` passed. Verified collapsed and expanded dark states, plus light mode, in macOS Safari Responsive Design Mode at 375 × 667 and 2×. Actual iOS Safari was not available for testing.
